### PR TITLE
fix(config): move sensitive settings to environment variables

### DIFF
--- a/lewa/.env.example
+++ b/lewa/.env.example
@@ -1,0 +1,1 @@
+SECRET_KEY="your-secret-key"

--- a/lewa/lewa/settings.py
+++ b/lewa/lewa/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+from decouple import config
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -20,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "insecure-0peo@#x9jur3!h$ryje!$879xww8y1y66jx!%*#ymhg&jkozs2"
+SECRET_KEY = config('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-decouple==3.8


### PR DESCRIPTION
fix(config): move sensitive settings to environment variables

- Installed python-decouple
- Updated settings.py to read SECRET_KEY from .env
- Added .env.example

Closes #10
